### PR TITLE
Update exKbd.py

### DIFF
--- a/Examples/exKbd.py
+++ b/Examples/exKbd.py
@@ -59,6 +59,9 @@ tA = KeyButton(BUTTON_A_PIN, keyboard = kbd, key = lv.KEY.PREV, debug= True)
 tB = KeyButton(BUTTON_B_PIN, keyboard = kbd, key = lv.KEY.ENTER, debug= True)
 tC = KeyButton(BUTTON_C_PIN, keyboard = kbd, key = lv.KEY.NEXT, debug= True)
 
+# register the device driver:
+kbd.registerDriver()
+
 # Create a group
 group = lv.group_create()
 lv.group_add_obj(group, btn1)
@@ -66,8 +69,5 @@ lv.group_add_obj(group, btn2)
 lv.group_add_obj(group, btn3)
 lv.group_add_obj(group, btn4)
 kbd.group = group
-
-# register the device driver:
-kbd.registerDriver()
 
 print("Setup finished...")


### PR DESCRIPTION
Driver was being initialized on the end. It would produce:
  File "main.py", line 66, in <module>
  File "m5inputs/base.py", line 178, in group
AttributeError: 'Keypad' object has no attribute '_driver'
If changed to before group creation it no longer gives an error.